### PR TITLE
fix detect device type error

### DIFF
--- a/Joy_caption_node.py
+++ b/Joy_caption_node.py
@@ -1,7 +1,7 @@
-
 from huggingface_hub import InferenceClient
 from torch import nn
-from transformers import AutoModel, AutoProcessor, AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast, AutoModelForCausalLM
+from transformers import AutoModel, AutoProcessor, AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast, \
+    AutoModelForCausalLM
 from pathlib import Path
 import torch
 import torch.amp.autocast_mode
@@ -13,52 +13,56 @@ from .lib.ximg import *
 from .lib.xmodel import *
 
 from model_management import get_torch_device
+
 DEVICE = get_torch_device()
-# def get_torch_device():  
-#     """  
-#     返回PyTorch模型应该运行的设备（CPU或GPU）  
-#     如果系统支持CUDA并且至少有一个GPU可用，则返回GPU设备；否则返回CPU设备。  
-#     """  
-#     if torch.cuda.is_available():  
-#         # 选择第一个可用的GPU  
-#         device = torch.device("cuda:0")  
-#         print(f"There are {torch.cuda.device_count()} GPU(s) available.")  
-#         print(f"We will use the GPU: {device}")  
-#     else:  
-#         # 如果没有GPU可用，则使用CPU  
-#         device = torch.device("cpu")  
-#         print("No GPU available, using the CPU instead.")  
+
+
+# def get_torch_device():
+#     """
+#     返回PyTorch模型应该运行的设备（CPU或GPU）
+#     如果系统支持CUDA并且至少有一个GPU可用，则返回GPU设备；否则返回CPU设备。
+#     """
+#     if torch.cuda.is_available():
+#         # 选择第一个可用的GPU
+#         device = torch.device("cuda:0")
+#         print(f"There are {torch.cuda.device_count()} GPU(s) available.")
+#         print(f"We will use the GPU: {device}")
+#     else:
+#         # 如果没有GPU可用，则使用CPU
+#         device = torch.device("cpu")
+#         print("No GPU available, using the CPU instead.")
 #     return device
 
 class JoyPipeline:
     def __init__(self):
         self.clip_model = None
-        self.clip_processor =None
+        self.clip_processor = None
         self.tokenizer = None
         self.text_model = None
         self.image_adapter = None
         self.parent = None
-    
+
     def clearCache(self):
         self.clip_model = None
-        self.clip_processor =None
+        self.clip_processor = None
         self.tokenizer = None
         self.text_model = None
-        self.image_adapter = None 
+        self.image_adapter = None
 
 
 class ImageAdapter(nn.Module):
-	def __init__(self, input_features: int, output_features: int):
-		super().__init__()
-		self.linear1 = nn.Linear(input_features, output_features)
-		self.activation = nn.GELU()
-		self.linear2 = nn.Linear(output_features, output_features)
-	
-	def forward(self, vision_outputs: torch.Tensor):
-		x = self.linear1(vision_outputs)
-		x = self.activation(x)
-		x = self.linear2(x)
-		return x
+    def __init__(self, input_features: int, output_features: int):
+        super().__init__()
+        self.linear1 = nn.Linear(input_features, output_features)
+        self.activation = nn.GELU()
+        self.linear2 = nn.Linear(output_features, output_features)
+
+    def forward(self, vision_outputs: torch.Tensor):
+        x = self.linear1(vision_outputs)
+        x = self.activation(x)
+        x = self.linear2(x)
+        return x
+
 
 class Joy_caption_load:
 
@@ -72,8 +76,8 @@ class Joy_caption_load:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model": (["unsloth/Meta-Llama-3.1-8B-bnb-4bit", "meta-llama/Meta-Llama-3.1-8B"],), 
-               
+                "model": (["unsloth/Meta-Llama-3.1-8B-bnb-4bit", "meta-llama/Meta-Llama-3.1-8B"],),
+
             }
         }
 
@@ -83,39 +87,40 @@ class Joy_caption_load:
 
     def loadCheckPoint(self):
         # 清除一波
-        if self.pipeline != None:
-            self.pipeline.clearCache() 
-       
-         # clip
-        model_id = "google/siglip-so400m-patch14-384"
-        CLIP_PATH = download_hg_model(model_id,"clip")
+        if self.pipeline is not None:
+            self.pipeline.clearCache()
 
-        clip_processor = AutoProcessor.from_pretrained(CLIP_PATH) 
+            # clip
+        model_id = "google/siglip-so400m-patch14-384"
+        CLIP_PATH = download_hg_model(model_id, "clip")
+
+        clip_processor = AutoProcessor.from_pretrained(CLIP_PATH)
         clip_model = AutoModel.from_pretrained(
-                CLIP_PATH,
-                trust_remote_code=True
-            )
-            
+            CLIP_PATH,
+            trust_remote_code=True
+        )
+
         clip_model = clip_model.vision_model
         clip_model.eval()
         clip_model.requires_grad_(False)
         clip_model.to("cuda")
 
-       
         # LLM
-        MODEL_PATH = download_hg_model(self.model,"LLM")
-        tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH,use_fast=False)
-        assert isinstance(tokenizer, PreTrainedTokenizer) or isinstance(tokenizer, PreTrainedTokenizerFast), f"Tokenizer is of type {type(tokenizer)}"
+        MODEL_PATH = download_hg_model(self.model, "LLM")
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, use_fast=False)
+        assert isinstance(tokenizer, PreTrainedTokenizer) or isinstance(tokenizer,
+                                                                        PreTrainedTokenizerFast), f"Tokenizer is of type {type(tokenizer)}"
 
-        text_model = AutoModelForCausalLM.from_pretrained(MODEL_PATH, device_map="auto",trust_remote_code=True)
+        text_model = AutoModelForCausalLM.from_pretrained(MODEL_PATH, device_map="auto", trust_remote_code=True)
         text_model.eval()
 
         # Image Adapter
-        adapter_path =  os.path.join(folder_paths.models_dir,"Joy_caption","image_adapter.pt")
+        adapter_path = os.path.join(folder_paths.models_dir, "Joy_caption", "image_adapter.pt")
 
-        image_adapter = ImageAdapter(clip_model.config.hidden_size, text_model.config.hidden_size) # ImageAdapter(clip_model.config.hidden_size, 4096) 
+        image_adapter = ImageAdapter(clip_model.config.hidden_size,
+                                     text_model.config.hidden_size)  # ImageAdapter(clip_model.config.hidden_size, 4096)
         image_adapter.load_state_dict(torch.load(adapter_path, map_location="cpu"))
-        adjusted_adapter =  image_adapter #AdjustedImageAdapter(image_adapter, text_model.config.hidden_size)
+        adjusted_adapter = image_adapter  # AdjustedImageAdapter(image_adapter, text_model.config.hidden_size)
         adjusted_adapter.eval()
         adjusted_adapter.to("cuda")
 
@@ -124,16 +129,17 @@ class Joy_caption_load:
         self.pipeline.tokenizer = tokenizer
         self.pipeline.text_model = text_model
         self.pipeline.image_adapter = adjusted_adapter
-    
-    def clearCache(self):
-         if self.pipeline != None:
-              self.pipeline.clearCache()
 
-    def gen(self,model):
-        if self.model == None or self.model != model or self.pipeline == None:
+    def clearCache(self):
+        if self.pipeline is not None:
+            self.pipeline.clearCache()
+
+    def gen(self, model):
+        if self.model is None or self.model != model or self.pipeline is None:
             self.model = model
             self.loadCheckPoint()
         return (self.pipeline,)
+
 
 class Joy_caption:
 
@@ -146,8 +152,8 @@ class Joy_caption:
             "required": {
                 "joy_pipeline": ("JoyPipeline",),
                 "image": ("IMAGE",),
-                "prompt":   ("STRING", {"multiline": True, "default": "A descriptive caption for this image"},),
-                "max_new_tokens":("INT", {"default": 1024, "min": 10, "max": 4096, "step": 1}),
+                "prompt": ("STRING", {"multiline": True, "default": "A descriptive caption for this image"},),
+                "max_new_tokens": ("INT", {"default": 1024, "min": 10, "max": 4096, "step": 1}),
                 "temperature": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "cache": ("BOOLEAN", {"default": False}),
             }
@@ -156,18 +162,17 @@ class Joy_caption:
     CATEGORY = "CXH/LLM"
     RETURN_TYPES = ("STRING",)
     FUNCTION = "gen"
-    def gen(self,joy_pipeline,image,prompt,max_new_tokens,temperature,cache): 
 
-        if joy_pipeline.clip_processor == None :
-            joy_pipeline.parent.loadCheckPoint()    
+    def gen(self, joy_pipeline, image, prompt, max_new_tokens, temperature, cache):
+
+        if joy_pipeline.clip_processor is None:
+            joy_pipeline.parent.loadCheckPoint()
 
         clip_processor = joy_pipeline.clip_processor
         tokenizer = joy_pipeline.tokenizer
         clip_model = joy_pipeline.clip_model
         image_adapter = joy_pipeline.image_adapter
         text_model = joy_pipeline.text_model
-
-     
 
         input_image = tensor2pil(image)
 
@@ -176,9 +181,10 @@ class Joy_caption:
         pImge = pImge.to(DEVICE)
 
         # Tokenize the prompt
-        prompt = tokenizer.encode(prompt, return_tensors='pt', padding=False, truncation=False, add_special_tokens=False)
+        prompt = tokenizer.encode(prompt, return_tensors='pt', padding=False, truncation=False,
+                                  add_special_tokens=False)
         # Embed image
-        with torch.amp.autocast_mode.autocast(str(DEVICE), enabled=True):
+        with torch.amp.autocast_mode.autocast(device_type=DEVICE.type, enabled=True):
             vision_outputs = clip_model(pixel_values=pImge, output_hidden_states=True)
             image_features = vision_outputs.hidden_states[-2]
             embedded_images = image_adapter(image_features)
@@ -186,8 +192,10 @@ class Joy_caption:
 
         # Embed prompt
         prompt_embeds = text_model.model.embed_tokens(prompt.to(DEVICE))
-        assert prompt_embeds.shape == (1, prompt.shape[1], text_model.config.hidden_size), f"Prompt shape is {prompt_embeds.shape}, expected {(1, prompt.shape[1], text_model.config.hidden_size)}"
-        embedded_bos = text_model.model.embed_tokens(torch.tensor([[tokenizer.bos_token_id]], device=text_model.device, dtype=torch.int64))   
+        assert prompt_embeds.shape == (1, prompt.shape[1],
+                                       text_model.config.hidden_size), f"Prompt shape is {prompt_embeds.shape}, expected {(1, prompt.shape[1], text_model.config.hidden_size)}"
+        embedded_bos = text_model.model.embed_tokens(
+            torch.tensor([[tokenizer.bos_token_id]], device=text_model.device, dtype=torch.int64))
 
         # Construct prompts
         inputs_embeds = torch.cat([
@@ -202,8 +210,10 @@ class Joy_caption:
             prompt,
         ], dim=1).to(DEVICE)
         attention_mask = torch.ones_like(input_ids)
-        
-        generate_ids = text_model.generate(input_ids, inputs_embeds=inputs_embeds, attention_mask=attention_mask, max_new_tokens=max_new_tokens, do_sample=True, top_k=10, temperature=temperature, suppress_tokens=None)
+
+        generate_ids = text_model.generate(input_ids, inputs_embeds=inputs_embeds, attention_mask=attention_mask,
+                                           max_new_tokens=max_new_tokens, do_sample=True, top_k=10,
+                                           temperature=temperature, suppress_tokens=None)
 
         # Trim off the prompt
         generate_ids = generate_ids[:, input_ids.shape[1]:]
@@ -213,7 +223,7 @@ class Joy_caption:
         caption = tokenizer.batch_decode(generate_ids, skip_special_tokens=False, clean_up_tokenization_spaces=False)[0]
         r = caption.strip()
 
-        if cache == False:
-           joy_pipeline.parent.clearCache()  
+        if not cache:
+            joy_pipeline.parent.clearCache()
 
         return (r,)


### PR DESCRIPTION
**修复cuda设备类型错误问题**

### 错误信息
raise RuntimeError( RuntimeError: User specified an unsupported autocast device_type 'cuda:0'
相关问题：https://github.com/StartHua/Comfyui_CXH_joy_caption/issues/38

该错误可在Windows端ComfyUI复现
```
# Embed image
        with torch.amp.autocast_mode.autocast(str(DEVICE), enabled=True):
            vision_outputs = clip_model(pixel_values=pImge, output_hidden_states=True)
            image_features = vision_outputs.hidden_states[-2]
            embedded_images = image_adapter(image_features)
            embedded_images = embedded_images.to(DEVICE)
```

在Windows端，当Cuda即str(DEVICE)为“cuda:0”，导致`with torch.amp.autocast_mode.autocast(str(DEVICE), enabled=True)`运行报错

### 解决办法
查看源码发现`torch.amp.autocast_mode.autocast`  方法输入参数
device_type(str, required):  Device type to use. Possible values are: 'cuda', 'cpu', 'xpu' and 'hpu'.
device_type设备类型只支持输入'cuda', 'cpu', 'xpu' and 'hpu' 这几个值

